### PR TITLE
タスク編集をパスパラメータに変更しました

### DIFF
--- a/src/main/java/com/example/demo/controller/TaskController.java
+++ b/src/main/java/com/example/demo/controller/TaskController.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
@@ -96,9 +97,9 @@ public class TaskController {
 	}
 
 	// タスクの編集画面の表示
-	@GetMapping("/tasks/edit")
+	@GetMapping("/task/{teskId}/edit")
 	public String edit(
-			@RequestParam Integer taskId,
+			@PathVariable Integer teskId,
 			Model model) {
 
 		// 全カテゴリーの取得
@@ -106,7 +107,7 @@ public class TaskController {
 		model.addAttribute("categories", categoryList);
 
 		// ID（主キー）で検索してタスク情報を取得
-		Task task = taskRepository.findById(taskId).get();
+		Task task = taskRepository.findById(teskId).get();
 
 		// Map.of()の簡易Mapで複数のデータをまとめて送る
 		model.addAllAttributes(Map.of(
@@ -117,9 +118,9 @@ public class TaskController {
 	}
 
 	// タスク更新処理
-	@PostMapping("/tasks/update")
+	@PostMapping("/task/{taskId}/update")
 	public String update(
-			@RequestParam Integer taskId,
+			@PathVariable Integer taskId,
 			@RequestParam Integer categoryId,
 			@RequestParam String title,
 			@RequestParam LocalDate closingDate,

--- a/src/main/resources/templates/task/editTask.html
+++ b/src/main/resources/templates/task/editTask.html
@@ -10,7 +10,7 @@
 
 	<h2>タスク変更</h2>
 
-	<form action="/tasks/update" method="post">
+	<form th:action="@{/task/{taskId}/update(taskId=${task.id})}" method="post">
 
 		<table class="">
 
@@ -65,7 +65,6 @@
 
 		</table>
 
-		<input type="hidden" name="taskId" th:value="${task.id}" />
 		<button>変更</button>
 	</form>
 

--- a/src/main/resources/templates/task/tasks.html
+++ b/src/main/resources/templates/task/tasks.html
@@ -40,8 +40,8 @@
 				<!--# Thymeleafはドットでつないだプロパティ呼び出しは、順にget〇〇() をたどっていく仕組み
 				 なので、task.getCategory().getName()と同じになる #-->
 				<td th:text="${task.category.name}" class=""></td>
-				<td th:text="${task.closingDate}" class=""></td>			
-				
+				<td th:text="${task.closingDate}" class=""></td>
+
 				<!--# th:switch を使って task.progress の値に応じて文字列を表示 #-->
 				<td th:switch="${task.progress}">
 					<span th:case="0">未着手</span>
@@ -49,15 +49,14 @@
 					<span th:case="2">完了</span>
 					<span th:case="*">不明</span>
 				</td>
-				
+
 				<!--# 作成日時の表示 #-->
 				<td th:text="${task.createdAt}" class=""></td>
 
 				<td class="">
-					<form action="/tasks/edit" method="get">
-						<input type="hidden" name="taskId" th:value="${task.id}">
-						<button class="">変更</button>
-					</form>
+					<a th:href="@{/task/{taskId}/edit(taskId=${task.id})}">
+						<button type="button">変更</button>
+					</a>
 				</td>
 				<td class="">
 					<form action="/tasks/delete" method="post">


### PR DESCRIPTION
クエリパラメータでの編集処理は下記内容から適切ではないと判断し、パスパラメータに変更しました

- クエリパラメータやGETリクエストは基本的にページの表示などに使用されるため
- パスパラメータから処理に値を渡すほうが確実
- 編集の処理においててパスパラメータのほうが一般的