### PR TITLE
タスク削除をパスパラメータに変更しました

### DIFF
--- a/src/main/java/com/example/demo/controller/TaskController.java
+++ b/src/main/java/com/example/demo/controller/TaskController.java
@@ -145,9 +145,9 @@ public class TaskController {
 	}
 
 	// タスクの削除処理
-	@PostMapping("/tasks/delete")
+	@PostMapping("/task/{taskId}/delete")
 	public String delete(
-			@RequestParam Integer taskId,
+			@PathVariable Integer taskId,
 			Model model) {
 
 		taskRepository.deleteById(taskId);

--- a/src/main/resources/templates/task/tasks.html
+++ b/src/main/resources/templates/task/tasks.html
@@ -59,9 +59,8 @@
 					</a>
 				</td>
 				<td class="">
-					<form action="/tasks/delete" method="post">
-						<input type="hidden" name="taskId" th:value="${task.id}">
-						<button class="">削除</button>
+					<form th:action="@{/task/{taskId}/delete(taskId=${task.id})}" method="post">
+						<button type="submit" class="">削除</button>
 					</form>
 				</td>
 			</tr>


### PR DESCRIPTION
クエリパラメータでの削除処理は下記内容から適切ではないと判断し、パスパラメータに変更しました

- RequestParamの場合、URLからどの削除を行っているのか分かりにくいため
- パスパラメータから処理に値を渡すほうが確実
- 削除処理においてパスパラメータのほうが一般的