### PR TITLE
ログインチェックのロジックを変更

### DIFF
--- a/src/main/java/com/example/demo/aop/CheckLoginAspect.java
+++ b/src/main/java/com/example/demo/aop/CheckLoginAspect.java
@@ -21,13 +21,14 @@ public class CheckLoginAspect {
 	// 全Controllerクラスの全メソッド処理前を指定
 	@Before("execution(* com.example.demo.controller.*Controller.*(..))")
 	public void writeLog(JoinPoint jp) {
+
 		// ログインしたアカウント情報を取得
-		if (account == null || account.getName() == null
-				|| account.getName().length() == 0) {
-			System.out.print("ゲスト：");
+		if (account.isLoggedIn()) {
+			System.out.print("アカウントID_" + account.getId() + "：");
 		} else {
-			System.out.print(account.getName() + "：");
+			System.out.print("未ログイン：");
 		}
+
 		System.out.println(jp.getSignature());
 	}
 
@@ -35,13 +36,13 @@ public class CheckLoginAspect {
 	@Around("execution(* com.example.demo.controller.TaskController.*(..))")
 	public Object checkLogin(ProceedingJoinPoint jp) throws Throwable {
 
-		if (account == null || account.getName() == null
-				|| account.getName().length() == 0) {
+		if (!account.isLoggedIn()) {
 			System.err.println("ログインしていません!");
 			// リダイレクト先を指定する
 			// パラメータを渡すことでログインControllerで
 			return "redirect:/login?error=notLoggedIn";
 		}
+
 		// Controller内のメソッドの実行
 		return jp.proceed();
 	}

--- a/src/main/java/com/example/demo/model/Account.java
+++ b/src/main/java/com/example/demo/model/Account.java
@@ -40,9 +40,9 @@ public class Account {
 		this.id = id;
 	}
 
-	// ログイン状態を確認するメソッド（未使用）
+	// ログイン状態を確認するメソッド
 	public boolean isLoggedIn() {
-		return id != null && name != null && !name.isEmpty();
+		return id != null;
 	}
 
 	// デバッグ・ログ出力用


### PR DESCRIPTION
ログインチェックをaccountモデルのnameフィールドで行っていたので、下記内容を考えた結果修正しました。

- ログインチェックを名前で行うことの違和感があり、idフィールドのほうが自然
- 名前をログに出力することは、個人情報の観点からヤバいと思った
- accountのログインチェックロジックが重複していたので、accountモデルが持つメソッドにしてまとめたい